### PR TITLE
Make the watering can not lose water in creative

### DIFF
--- a/tools.lua
+++ b/tools.lua
@@ -65,7 +65,9 @@ minetest.register_tool("crops:watering_can", {
 		water = math.min(water + crops.settings.watercan, crops.settings.watercan_max)
 		meta:set_int("crops_water", water)
 
-		itemstack:set_wear(math.min(65534, wear + (65535 / crops.settings.watercan_uses)))
+		if not minetest.setting_getbool("creative_mode") then
+			itemstack:set_wear(math.min(65534, wear + (65535 / crops.settings.watercan_uses)))
+		end
 		return itemstack
 	end,
 })


### PR DESCRIPTION
It seems a bit silly for the can to lose water, when you can get infinite water from your inventory.
